### PR TITLE
Fixes sizing issue with Project Decription overlapping the native mobile screens

### DIFF
--- a/src/content/work/Car-Sales.md
+++ b/src/content/work/Car-Sales.md
@@ -11,7 +11,6 @@ tags:
   - Data-Viz
 permalink: https://github.com/Sonya-7/Car_Sales_Dashboard
 ---
-export const prerender = true;
 
 ## Details
 

--- a/src/content/work/DS-IBM-Capstone.md
+++ b/src/content/work/DS-IBM-Capstone.md
@@ -12,7 +12,6 @@ tags:
   - SQL
 permalink: https://docs.google.com/presentation/d/1D1IVyxTffZ7tjNsF4RizdzksX14EEE6i/edit?usp=sharing&ouid=110833041343711162548&rtpof=true&sd=true
 ---
-export const prerender = true;
 
 ## Introduction
 This capstone project predicts the likelihood of the Falcon 9 first stage landing successfully. SpaceX advertises Falcon 9 rocket launches on its website with a cost of $62 million; other providers cost upward of $165 million each. Much of the savings is because SpaceX can reuse the first stage of it's rockets after launch. If we can determine whether the first stage will land, we can estimate the cost of a launch. This information can prove to be very insightful for an alternate company that wants to bid against SpaceX for a rocket launch.

--- a/src/content/work/ML-Basketball.md
+++ b/src/content/work/ML-Basketball.md
@@ -11,7 +11,6 @@ tags:
   - Classification
 permalink: https://dataplatform.cloud.ibm.com/analytics/notebooks/v2/98cc15ea-9aae-4589-8167-41d10ca95476/view?access_token=5f45ee82c2f6db1ea945e79bfd935e51e3c9eb0cff038bf204c07aef2c361a6c
 ---
-export const prerender = true;
 
 ### Objective
 Apply Machine learning to a dataset to make inferences about a basketball team's likelihood of making it to the final four.

--- a/src/content/work/Reading-Trends.md
+++ b/src/content/work/Reading-Trends.md
@@ -11,7 +11,6 @@ tags:
   - Personal Growth
 permalink: https://github.com/Sonya-7/Reading_List
 ---
-export const prerender = true;
 
 ## Project Description
 This project showcases a comprehensive collection of books I have read since January 2021. It presents engaging word clouds and an interactive dashboard, offering a captivating visualization of my literary journey.

--- a/src/content/work/Russian-Invasion.md
+++ b/src/content/work/Russian-Invasion.md
@@ -11,7 +11,6 @@ tags:
   - Data-Viz
 permalink: https://www.kaggle.com/code/sonyalawrence/russian-invasion-of-ukraine
 ---
-export const prerender = true;
 
 ## Project History
 This is an assessment of the equipment and personnel loss in the Russian invasion of Ukraine. Several visualization tools including bar charts, geospatial maps, area charts, and box plots are used to show trends and patterns observed in the data. 

--- a/src/content/work/Salaries.md
+++ b/src/content/work/Salaries.md
@@ -13,7 +13,7 @@ permalink: https://www.kaggle.com/code/sonyalawrence/data-salaries-in-north-amer
 ---
 export const prerender = true;
 
-# Project Description
+## Project Description
 This assessment is an in-depth analysis of the salary details for North American employers whose employees are also located in North America. <br />
 
 ### ***<ins>Demographics</ins>***

--- a/src/content/work/Salaries.md
+++ b/src/content/work/Salaries.md
@@ -11,7 +11,6 @@ tags:
   - Data-Viz
 permalink: https://www.kaggle.com/code/sonyalawrence/data-salaries-in-north-america
 ---
-export const prerender = true;
 
 ## Project Description
 This assessment is an in-depth analysis of the salary details for North American employers whose employees are also located in North America. <br />


### PR DESCRIPTION
Before: 
<img width="429" alt="Screen Shot 2024-05-07 at 2 22 55 PM" src="https://github.com/Sonya-7/PersonalWebsite/assets/92260713/d8d06844-3cf8-45dc-a46d-e0bfe4d4124d">

After: 
<img width="429" alt="Screen Shot 2024-05-07 at 2 23 12 PM" src="https://github.com/Sonya-7/PersonalWebsite/assets/92260713/1f1d2596-78ec-41f4-8ec7-bf8beb8ca561">
